### PR TITLE
prefer parent modification over id reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "dotenv": "^8.2.0",
     "eris": "^0.16.1",
     "fastify": "^3.9.2",
-    "slash-create": "5.0.1"
+    "slash-create": "^5.0.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.11",

--- a/src/commands/game-config.ts
+++ b/src/commands/game-config.ts
@@ -30,7 +30,7 @@ export default class GameConfig extends SlashCommand<ErisClient> {
 
     ctx.registerComponent("toggle-private", ctx => {
       game.isPrivate = !game.isPrivate;
-      ctx.edit(ctx.message.id, this.buildConfigView(ctx, game));
+      ctx.editParent(this.buildConfigView(ctx, game));
 
       ctx.sendFollowUp("Game is now " + (game.isPrivate ? "Private" : "Public"), { ephemeral: true });
 

--- a/src/util/game.ts
+++ b/src/util/game.ts
@@ -307,6 +307,8 @@ export function registerComponents(client: ErisClient, creator: SlashCreator) {
 
     if (gamePromptID) {
       await client.editMessage(channelID, gamePromptID, {
+        content: "",
+        embeds: [],
         components: [{
           type: ComponentType.ACTION_ROW,
           components: [{


### PR DESCRIPTION
This is a minor change to use the built-in method from the context itself.

* `ctx.edit` -> `ctx.editParent`