### PR TITLE
patch: force setup response as ephemeral

### DIFF
--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -72,11 +72,11 @@ export default class SetupCommand extends SlashCommand<Client> {
   async run(ctx: CommandContext) {
     const lobbyOptions = lobbyChannels.get(ctx.guildID);
 
-    const response = ctx.options.skip_confirm as boolean
-      ? 'Setting up game handler...'
+    const response = (ctx.options.skip_confirm as boolean)
+      ? { content : 'Setting up game handler...' }
       : this.getConfirmMessage(ctx.options as SetupOptions, lobbyOptions)
 
-    await ctx.send(response, { ephemeral: true });
+    await ctx.send({ ...response, ephemeral: true });
 
     await ctx.fetch();
 


### PR DESCRIPTION
`/setup` now responds as an ephemeral message.

- fixes #7 

https://user-images.githubusercontent.com/8607699/167418265-8afba1f2-4993-44d3-b5fa-1f6cd9cad250.mp4


