### PR TITLE
patch: change reply wording to refer within bot

### DIFF
--- a/src/components/accept.ts
+++ b/src/components/accept.ts
@@ -8,12 +8,12 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   const { channelID, gamePromptID } = lobbyChannels.get(ctx.guildID);
 
   if (!game) {
-    ctx.send('You are not in a game', { ephemeral: true });
+    ctx.send('I do not recognize this channel as a lobby channel.', { ephemeral: true });
     return;
   }
 
   if (game.host.id !== ctx.member.id) {
-    ctx.send('You are not the host of this game', { ephemeral: true });
+    ctx.send('You are not the host of this game.', { ephemeral: true });
     return;
   }
 

--- a/src/components/decline.ts
+++ b/src/components/decline.ts
@@ -7,12 +7,12 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   const game = games.get(ctx.channelID);
 
   if (!game) {
-    ctx.send('You are not in a game', { ephemeral: true });
+    ctx.send('I do not recognize this channel as a lobby channel.', { ephemeral: true });
     return;
   }
 
   if (game.host.id !== ctx.member.id) {
-    ctx.send('You are not the host of this game', { ephemeral: true });
+    ctx.send('You are not the host of this game.', { ephemeral: true });
     return;
   }
 

--- a/src/components/delete.ts
+++ b/src/components/delete.ts
@@ -24,12 +24,12 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   const { channelID, gamePromptID } = lobbyChannels.get(ctx.guildID);
 
   if (!game) {
-    ctx.send('You are not in a game', { ephemeral: true });
+    ctx.send('I do not recognize this channel as a lobby channel.', { ephemeral: true });
     return;
   }
 
   if (game.host.id !== ctx.member.id) {
-    ctx.send('You are not the host of this game', { ephemeral: true });
+    ctx.send('You are not the host of this game.', { ephemeral: true });
     // game.log.push({ type: "interaction: delete-game", context: clone(ctx) });
     return;
   }

--- a/src/components/join.ts
+++ b/src/components/join.ts
@@ -25,16 +25,16 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
     return reply('I do not recognize this channel as a lobby channel.');
   }
 
+  if (game.players.length >= 15) {
+    return reply('The game is full.');
+  }
+
   if (game.players.some((p) => p.id === ctx.member.id)) {
     return reply('You are already in the game lobby.');
   }
 
   if (game.requests.some((r) => r.id === ctx.member.id)) {
     return reply('You have already requested to join this game.');
-  }
-
-  if (game.players.length >= 15) {
-    return reply('The game is full.');
   }
 
   // try {

--- a/src/components/join.ts
+++ b/src/components/join.ts
@@ -22,7 +22,7 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   };
 
   if (!game) {
-    return reply('There is no game in progress.');
+    return reply('I do not recognize this channel as a game lobby.');
   }
 
   if (game.players.some((p) => p.id === ctx.member.id)) {

--- a/src/components/join.ts
+++ b/src/components/join.ts
@@ -7,7 +7,7 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
 
   // ensure interaction is from the lobby channel
   if (ctx.channelID !== channelID) {
-    ctx.send('Unknown interaction origin...');
+    ctx.send('Unknown interaction origin.');
     return;
   }
 
@@ -22,11 +22,11 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   };
 
   if (!game) {
-    return reply('I do not recognize this channel as a game lobby.');
+    return reply('I do not recognize this channel as a lobby channel.');
   }
 
   if (game.players.some((p) => p.id === ctx.member.id)) {
-    return reply('You are already in the game.');
+    return reply('You are already in the game lobby.');
   }
 
   if (game.requests.some((r) => r.id === ctx.member.id)) {
@@ -84,7 +84,7 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
       ]
     });
 
-    return reply('Request sent.');
+    return reply('Your request has been sent.');
   } else {
     game.players.push(ctx.member);
 
@@ -114,7 +114,7 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
     await client.createMessage(game.id, {
       embeds: [
         {
-          title: `${ctx.member.nick || ctx.user.username} has joined the game.`,
+          title: `${ctx.member.mention} has joined the game.`,
           thumbnail: {
             url: ctx.member.avatarURL
           },

--- a/src/components/join.ts
+++ b/src/components/join.ts
@@ -5,14 +5,6 @@ import { lobbyChannels, games, buildPost } from '../util/game';
 export default async (ctx: ComponentContext, client: ErisClient) => {
   const { channelID, gamePromptID } = lobbyChannels.get(ctx.guildID);
 
-  // ensure interaction is from the lobby channel
-  if (ctx.channelID !== channelID) {
-    ctx.send('Unknown interaction origin.');
-    return;
-  }
-
-  const game = games.get(ctx.message.embeds[0].footer.text);
-
   const reply = (options: MessageOptions | string) => {
     if (typeof options === 'string') {
       options = { content: options };
@@ -20,6 +12,14 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
 
     ctx.send({ ...options, ephemeral: true });
   };
+
+  // ensure interaction is from the lobby channel
+  if (ctx.channelID !== channelID) {
+    reply('Unknown interaction origin.');
+    return;
+  }
+
+  const game = games.get(ctx.message.embeds[0].footer.text);
 
   if (!game) {
     return reply('I do not recognize this channel as a lobby channel.');

--- a/src/components/join.ts
+++ b/src/components/join.ts
@@ -15,8 +15,7 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
 
   // ensure interaction is from the lobby channel
   if (ctx.channelID !== channelID) {
-    reply('Unknown interaction origin.');
-    return;
+    return reply('Unknown interaction origin.');
   }
 
   const game = games.get(ctx.message.embeds[0].footer.text);
@@ -45,7 +44,7 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   if (game.isPrivate) {
     game.requests.push(ctx.member);
 
-    client.createMessage(game.id, {
+    await client.createMessage(game.id, {
       content: `<@${game.host.id}>`,
       embeds: [
         {

--- a/src/components/leave.ts
+++ b/src/components/leave.ts
@@ -45,7 +45,7 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   await client.createMessage(game.id, {
     embeds: [
       {
-        title: `${ctx.member.nick || ctx.user.username} has left the game.`,
+        title: `${ctx.member.mention} has left the game.`,
         thumbnail: {
           url: ctx.member.avatarURL
         },

--- a/src/components/new-game.ts
+++ b/src/components/new-game.ts
@@ -37,7 +37,7 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   const { channelID: lobbyChannelID, gamePromptID, categoryID } = lobbyChannels.get(ctx.guildID);
 
   if (ctx.channelID !== lobbyChannelID) {
-    ctx.send('Unknown interaction origin...', { ephemeral: true });
+    ctx.send('Unknown interaction origin.', { ephemeral: true });
     return;
   }
 

--- a/src/components/toggle-access.ts
+++ b/src/components/toggle-access.ts
@@ -8,12 +8,12 @@ export default async (ctx: ComponentContext, client: ErisClient) => {
   const lobbyChannelID = lobbyChannels.get(ctx.guildID)?.channelID;
 
   if (!game) {
-    ctx.send('Unknown interaction origin...');
+    ctx.send('I do not recognize this channel as a lobby channel.', { ephemeral: true });
     return;
   }
 
   if (game.host.id !== ctx.member.id) {
-    ctx.send('You are not the host of this game...');
+    ctx.send('You are not the host of this game.', { ephemeral: true });
     return;
   }
 


### PR DESCRIPTION
* prior: reference could be made to other bots with similar functions without knowing who they are or what they do
* now: refer internally as to the perspective of the bot and it's `games` collection (imported from `util/game.ts`)