### PR TITLE
feat(vote): relative time remaining + embed

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Deception is a bot made as a prototype to manage game lobbies for community serv
 - [Apr 2nd 2022 - Vote mockup](https://twitter.com/TinkerStorm/status/1510042509321379842)
 - [May 7th 2022 - Full automation](https://twitter.com/TinkerStorm/status/1523051267454824448) - #2
   - [May 10th 2022 - Ephemeral setup wizard](https://twitter.com/TinkerStorm/status/1523806105117376512) - #10
-- [Jun 18th 2022 - Vote coundown](https://twitter.com/TinkerStorm/status/1538190111959044104) - #27 
+- [Jun 18th 2022 - Vote countdown](https://twitter.com/TinkerStorm/status/1538190111959044104) - #27
 
 ## License
 

--- a/src/commands/vote-mockup.ts
+++ b/src/commands/vote-mockup.ts
@@ -80,6 +80,15 @@ export default class VoteMockupCommand extends SlashCommand<Client> {
       ballot.set(selectCtx.user.id, newVote);
       await selectCtx.send(`You have voted for <@${newVote}>.`, { ephemeral: true });
 
+      game.log.push({
+        type: 'vote-success',
+        context: {
+          origin: selectCtx.user.id,
+          oldVote: currentVote,
+          newVote
+        }
+      });
+
       await selectCtx.editParent({
         embeds: [getBallotEmbed()]
       });

--- a/src/commands/vote-mockup.ts
+++ b/src/commands/vote-mockup.ts
@@ -20,7 +20,7 @@ export default class VoteMockupCommand extends SlashCommand<Client> {
     const game = games.get(ctx.channelID);
 
     const start = Date.now();
-    const duration = 1000 * 5;
+    const duration = 1000 * 20;
     const ballot = new Map<string, string>();
 
     const getRemainingTime = () => `<t:${Math.round((start + duration) / 1000)}:R>`;
@@ -85,7 +85,7 @@ export default class VoteMockupCommand extends SlashCommand<Client> {
       });
     });
 
-    await wait(duration - 500); // 20 seconds minus 1 second for the wait() - idk why
+    await wait(duration - 1000); // 20 seconds minus 1 second for the wait - idk why
     ctx.unregisterComponent('vote');
 
     // determine group of players who voted the same

--- a/src/experiments/BallotInstance.ts
+++ b/src/experiments/BallotInstance.ts
@@ -1,0 +1,53 @@
+import EventEmitter from 'events';
+import { IGame } from '../util/types';
+
+const gradient = 2.2;
+const offset = 8.1;
+
+export class BallotInstance extends EventEmitter {
+  startedAt = Date.now();
+
+  constructor(public game: IGame, public durationMs: number) {
+    super({
+      captureRejections: false
+    });
+  }
+
+  get remainingPlayerCount() {
+    return 8;
+    // return this.game.players.filter(player => player.alive).length
+  }
+
+  get totalPlayerCount() {
+    return this.game.players.length; // max at 25... because of component limits
+  }
+
+  // https://www.desmos.com/calculator/4alamggh46
+  get duration() {
+    return Math.round((this.totalPlayerCount / this.remainingPlayerCount) * gradient + offset)
+  }
+
+  get remaniningTime() {
+    return this.startedAt + this.durationMs - Date.now();
+  }
+
+  waitFor(event: string | symbol, timeout?: number) {
+    const start = Date.now();
+
+    return new Promise((resolve, reject) => {
+      const listener = () => {
+        if (ref) clearTimeout(ref);
+        resolve(Date.now() - start);
+      };
+
+      this.once(event, listener);
+
+      if (!timeout) return;
+
+      const ref = setTimeout(() => {
+        this.off(event, listener);
+        reject(Date.now() - start);
+      }, timeout);
+    });
+  }
+}


### PR DESCRIPTION
closes #26 

- Remaining time is tracked internally within the command execution scope itself
  > While the notation of `<t:{round(timeMs/1000)}:R>` can be used, there is still significant latency within the second it is due to expire. This may be due to network latency on local testing, or natural latency when Discord communicates with the host machine (or vice-versa in response).
- Vote mockup now has an embed which uses the randomly provided game `color` and `title`
![image](https://user-images.githubusercontent.com/8607699/174446299-1314061e-f318-473d-8091-737fb7ee832d.png)

https://user-images.githubusercontent.com/8607699/174449942-9f340610-331c-4dc8-9b82-5e7e0ad2ffd6.mp4